### PR TITLE
Translate core interface to English

### DIFF
--- a/about.py
+++ b/about.py
@@ -14,7 +14,7 @@ AUTHOR_IMG_PATH = os.path.join(current_dir, "assets", "author_photo.png")
 class AboutGameForm(tk.Toplevel):
     def __init__(self, master=None):
         super().__init__(master)
-        self.title("О аутору")
+        self.title("About the Author")
 
         # Make this form modal (optional)
         if master is not None:
@@ -47,24 +47,22 @@ class AboutGameForm(tk.Toplevel):
 
         # A label with some “demo text” about the author
         about_text = (
-            "О аутору:\n\n"
-            "Ову игру је осмислио Александар Бошковић, визионар у свету игара и човек \n"
-            "који је убеђен да је програмски код само модерни облик магије. Када \n"
-            "не ствара невероватне игре, најчешће га можете наћи како се пита \n"
-            "да ли је боље дебаговати код или направити нови универзум од нуле.\n\n"
-            
-            "А ко је био програмер? Па, ту ступам ја, OpenAI-јева вештачка интелигенција!\n"
-            "Као ChatGPT, мој главни задатак је био да претворим Ацину креативну\n"
-            "лудачку визију у логичан и функционалан код. Нисам пио кафу, нисам \n"
-            "се жалио на умор, али сам зато неколико пута покушао да убедим петљу\n"
-            "да не иде у бесконачност. Да ли сам робот? Да. Да ли сам се збунио\n"
-            "када сам покушао да схватим људски хумор? Апсолутно.\n\n"
-            
-            "Контакт (аутор): alexboshkovic@gmail.com\n"
-            "Контакт (AI програмер): Напишите '/help', али не обећавам да ћу вам поправити багове!\n\n"
-            
-            "2023 © Сва права задржана. Ако се игра сруши, кривите багове. Ако не, кривите срећу!\n\n"
-            "Посвећено Борису, Лени и Дуњи"
+            "About the author:\n\n"
+            "This game was created by Aleksandar Bošković, a visionary in the world of games and a man \n"
+            "convinced that programming code is simply a modern form of magic. When he isn't creating \n"
+            "incredible games, you can usually find him wondering whether it's better to debug code or \n"
+            "build a brand new universe from scratch.\n\n"
+
+            "And who was the programmer? That's where I come in, OpenAI's artificial intelligence!\n"
+            "As ChatGPT, my main task was to turn Aca's creative, crazy vision into logical and functional code. \n"
+            "I didn't drink coffee, never complained about being tired, but I did try several times to convince a loop \n"
+            "not to run forever. Am I a robot? Yes. Did I get confused trying to understand human humor? Absolutely.\n\n"
+
+            "Contact (author): alexboshkovic@gmail.com\n"
+            "Contact (AI programmer): Type '/help', but I can't promise I'll fix your bugs!\n\n"
+
+            "2023 © All rights reserved. If the game crashes, blame the bugs. If not, blame luck!\n\n"
+            "Dedicated to Boris, Lena, and Dunja"
         )
 
 
@@ -72,7 +70,7 @@ class AboutGameForm(tk.Toplevel):
         lbl_about.pack(pady=10)
 
         # Close button
-        btn_close = ttk.Button(main_frame, text="Затвори", command=self.destroy)
+        btn_close = ttk.Button(main_frame, text="Close", command=self.destroy)
         btn_close.pack(pady=5)
 
 def main(parent=None):

--- a/gameAsocijacije.py
+++ b/gameAsocijacije.py
@@ -39,7 +39,7 @@ def normalize_serbian(s: str) -> str:
 class AsocijacijaIgra:
     def __init__(self, root):
         self.root = root
-        self.root.title("Asocijacije -učimo engleski")
+        self.root.title("Associations - Learn English")
 
         # Load background image.
         self.bg_image = Image.open(BACKGROUND_IMAGE_PATH)
@@ -60,8 +60,13 @@ class AsocijacijaIgra:
         self.frame_window = self.canvas.create_window(0, 50, window=self.main_frame, anchor="nw", width=1024)
 
         # Widgets in the main_frame.
-        self.score_label = tk.Label(self.main_frame, text=f"Rezultat: {self.score}", font=("Impact", 14),
-                                    fg="blue", bg="lightblue")
+        self.score_label = tk.Label(
+            self.main_frame,
+            text=f"Score: {self.score}",
+            font=("Impact", 14),
+            fg="blue",
+            bg="lightblue",
+        )
         self.score_label.pack(pady=5)
 
         self.info_label = tk.Label(self.main_frame, text="", font=("Arial", 14), fg="black", bg="lightblue")
@@ -70,7 +75,7 @@ class AsocijacijaIgra:
         self.puzzle_frame = tk.Frame(self.main_frame, bg="lightblue")
         self.puzzle_frame.pack()
 
-        self.next_game_button = tk.Button(self.main_frame, text="Sledeća igra", command=self._next_game)
+        self.next_game_button = tk.Button(self.main_frame, text="Next Puzzle", command=self._next_game)
         self.next_game_button.pack(pady=5)
         self.next_game_button.config(state="disabled")
 
@@ -159,10 +164,10 @@ class AsocijacijaIgra:
         final_frame = tk.Frame(self.puzzle_frame, pady=20, bg="lightblue")
         final_frame.grid(row=1, columnspan=4)
 
-        tk.Label(final_frame, text="Konačno rešenje:", font=("Arial", 12), bg="lightblue").pack()
+        tk.Label(final_frame, text="Final answer:", font=("Arial", 12), bg="lightblue").pack()
         self.final_entry = tk.Entry(final_frame)
         self.final_entry.pack(pady=2)
-        final_btn = tk.Button(final_frame, text="Potvrdi", command=self._check_final_solution)
+        final_btn = tk.Button(final_frame, text="Submit", command=self._check_final_solution)
         final_btn.pack(pady=2)
 
     def _normalize_input(self, text: str) -> str:
@@ -211,14 +216,14 @@ class AsocijacijaIgra:
 
                 self.solved_columns[col] = True
                 self.info_label.config(
-                    text=f"Kolona {col} je rešena! +{points_for_column} poena.",
+                    text=f"Column {col} solved! +{points_for_column} points.",
                     fg="green"
                 )
                 self._reveal_all_in_column(col)
             else:
-                self.info_label.config(text="Kolona je već rešena.", fg="orange")
+                self.info_label.config(text="Column already solved.", fg="orange")
         else:
-            self.info_label.config(text="Netačno rešenje za kolonu.", fg="red")
+            self.info_label.config(text="Incorrect column answer.", fg="red")
 
     def _check_final_solution(self):
         if not self.final_solved:
@@ -242,7 +247,7 @@ class AsocijacijaIgra:
                 self._update_score()
 
                 self.info_label.config(
-                    text=f"Bravo! Krajnje rešenje je: {valid_final_answers[0]} (+{total_final_points} poena)",
+                    text=f"Bravo! Final answer is: {valid_final_answers[0]} (+{total_final_points} points)",
                     fg="green"
                 )
 
@@ -256,31 +261,31 @@ class AsocijacijaIgra:
 
                 self.next_game_button.config(state="normal")
             else:
-                self.info_label.config(text="Netačno krajnje rešenje.", fg="red")
+                self.info_label.config(text="Incorrect final answer.", fg="red")
         else:
-            self.info_label.config(text="Krajnje rešenje je već pogođeno.", fg="orange")
+            self.info_label.config(text="Final answer already guessed.", fg="orange")
 
     def _update_score(self):
-        self.score_label.config(text=f"Rezultat: {self.score}")
+        self.score_label.config(text=f"Score: {self.score}")
 
     def _next_game(self):
         self.puzzle_index += 1
         if self.puzzle_index < len(puzzle_data):
             self._load_puzzle(self.puzzle_index)
         else:
-            self.info_label.config(text="Nema više igara!", fg="blue")
+            self.info_label.config(text="No more puzzles!", fg="blue")
             self.next_game_button.config(state="disabled")
 
 def main(parent=None):
     if parent is None:
         root = tk.Tk()
-        root.title("Asocijacije")
+        root.title("Associations")
         root.resizable(True, True)
         app = AsocijacijaIgra(root)
         root.mainloop()
     else:
         top = tk.Toplevel(parent)
-        top.title("Asocijacije")
+        top.title("Associations")
         top.resizable(True, True)
         top.grab_set()
         top.focus_set()

--- a/gameRecenice.py
+++ b/gameRecenice.py
@@ -13,7 +13,7 @@ class RecenicaIgra:
         :param putanja_bgr: Putanja do slike za pozadinu.
         """
         self.root = root
-        self.root.title("Нестала слова")
+        self.root.title("Missing Letters")
         self.root.geometry("1024x768")  # Fiksne dimenzije
         # Allow the window to be resized
         self.root.resizable(True, True)
@@ -51,12 +51,12 @@ class RecenicaIgra:
         self.frame_navigacija = tk.Frame(self.root, bg="white")
         self.frame_navigacija.pack(pady=10)
         self.btn_prethodni = tk.Button(
-            self.frame_navigacija, text="Претходна",
+            self.frame_navigacija, text="Previous",
             command=self.prethodni, font=("Arial", 12), bg="lightblue"
         )
         self.btn_prethodni.grid(row=0, column=0, padx=5)
         self.btn_sledeci = tk.Button(
-            self.frame_navigacija, text="Следећа",
+            self.frame_navigacija, text="Next",
             command=self.sledeci, font=("Arial", 12), bg="lightgreen",
             state=tk.DISABLED  # Onemogućeno dok rečenica nije tačna
         )
@@ -66,7 +66,7 @@ class RecenicaIgra:
         )
         self.lbl_progress.grid(row=0, column=2, padx=10)
         self.btn_zavrsi = tk.Button(
-            self.frame_navigacija, text="Заврши игру", font=("Arial", 12), bg="tomato",
+            self.frame_navigacija, text="Finish Game", font=("Arial", 12), bg="tomato",
             command=self.zavrsi_igru
         )
         self.btn_zavrsi.grid(row=0, column=3, padx=5)
@@ -91,7 +91,7 @@ class RecenicaIgra:
         """
         rezultati = []
         if not os.path.exists(putanja):
-            messagebox.showerror("Greška", f"Fajl {putanja} nije pronađen.")
+            messagebox.showerror("Error", f"File {putanja} not found.")
             return rezultati
 
         with open(putanja, "r", encoding="utf-8") as f:
@@ -224,9 +224,9 @@ class RecenicaIgra:
 
     def proveri_recenicu(self):
         """
-        Proverava da li je trenutni raspored izabranih reči tačan.
-        Ako su izabrane sve reči i redosled odgovara originalnoj rečenici,
-        omogućava se dugme 'Следећа'.
+        Checks whether the current arrangement of selected words is correct.
+        If all words are selected and in the proper order,
+        the 'Next' button is enabled.
         """
         if len(self.selected_buttons) != len(self.trenutna_recenica):
             self.btn_sledeci.config(state=tk.DISABLED)
@@ -255,7 +255,7 @@ class RecenicaIgra:
         """Ažurira prikaz napretka (Rečenica X od Y)."""
         indeks_prikaz = self.trenutni_indeks + 1
         self.lbl_progress.config(
-            text=f"Реченица {indeks_prikaz}/{self.ukupno_recenica}" if self.ukupno_recenica > 0 else "Нема реченица"
+            text=f"Sentence {indeks_prikaz}/{self.ukupno_recenica}" if self.ukupno_recenica > 0 else "No sentences"
         )
 
     def zavrsi_igru(self):
@@ -280,17 +280,17 @@ def main(parent=None):
 
     if parent is None:
         root = tk.Tk()
-        root.title("Recenica Igra")
+        root.title("Sentence Game")
         # Allow resizing of the main window
         root.resizable(True, True)
         if os.path.exists(putanja_fajla):
             app = RecenicaIgra(root, putanja_fajla, IMAGES_FILE_PATH, putanja_bgr)
             root.mainloop()
         else:
-            print("Nije izabran fajl, izlaz iz programa.")
+            print("No file selected, exiting program.")
     else:
         top = tk.Toplevel(parent)
-        top.title("Recenica Igra")
+        top.title("Sentence Game")
         # Allow maximizing/minimizing.
         top.resizable(True, True)
         top.grab_set()
@@ -301,7 +301,7 @@ def main(parent=None):
             RecenicaIgra(top, putanja_fajla, IMAGES_FILE_PATH, putanja_bgr)
             top.wait_window()
         else:
-            messagebox.showerror("Greška", "Fajl sa реченицама nije pronađen.")
+            messagebox.showerror("Error", "Sentence file not found.")
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -272,23 +272,23 @@ class MainGameLauncher(tk.Tk):
                                             BTN_WIDTH_PX, BTN_HEIGHT_PX)
         # Each tuple: (Button Text, game launch function, Row, Column)
         buttons_info = [
-            ("Погоди ко сам", lambda: self.run_game(lambda: launch_pogodi(self)), 1, 0),
-            ("Меморија", lambda: self.run_game(lambda: launch_memory_game(self)), 1, 1),
-            ("Матадор", lambda: self.run_game(lambda: launch_shooter(self)), 1, 2),
-            ("Асоцијације", lambda: self.run_game(lambda: launch_asocijacije(self)), 1, 3),
-            ("Бојанка", lambda: self.run_game(lambda: launch_coloring(self)), 2, 0),
-            ("Програмер", lambda: self.run_game(lambda: launch_program(self)), 2, 1),
-            ("Судоку", lambda: self.run_game(lambda: launch_emoji_sudoku(self)), 2, 2),
-            ("Речи", lambda: self.run_game(lambda: launch_words(self)), 2, 3),
-            ("Слагалица", lambda: self.run_game(lambda: launch_puzzle(self)), 3, 0),
-            ("Нестала слова", lambda: self.run_game(lambda: launch_recenice_game(self)), 3, 1),
-            ("Сабирам и одузимам", lambda: self.run_game(lambda: launch_basicops(self)), 3, 2),
-            ("Кефалица", lambda: self.run_game(lambda: launch_main_game(self)), 3, 3),
-            ("Коцкице", lambda: self.run_game(lambda: launch_kocke_game(self)), 4, 1),
-            ("Сортирање", lambda: self.run_game(lambda: launch_sort_game(self)), 4, 2),
-            ("Спајалица", lambda: self.run_game(lambda: launch_position_game(self)), 4, 3),
-            ("Змије и мердевине", lambda: self.run_game(lambda: launch_snake_game(self)), 4, 0)
-           
+            ("Guess Who I Am", lambda: self.run_game(lambda: launch_pogodi(self)), 1, 0),
+            ("Memory", lambda: self.run_game(lambda: launch_memory_game(self)), 1, 1),
+            ("Mathador", lambda: self.run_game(lambda: launch_shooter(self)), 1, 2),
+            ("Associations", lambda: self.run_game(lambda: launch_asocijacije(self)), 1, 3),
+            ("Coloring", lambda: self.run_game(lambda: launch_coloring(self)), 2, 0),
+            ("Programmer", lambda: self.run_game(lambda: launch_program(self)), 2, 1),
+            ("Sudoku", lambda: self.run_game(lambda: launch_emoji_sudoku(self)), 2, 2),
+            ("Words", lambda: self.run_game(lambda: launch_words(self)), 2, 3),
+            ("Puzzle", lambda: self.run_game(lambda: launch_puzzle(self)), 3, 0),
+            ("Missing Letters", lambda: self.run_game(lambda: launch_recenice_game(self)), 3, 1),
+            ("Add and Subtract", lambda: self.run_game(lambda: launch_basicops(self)), 3, 2),
+            ("Kefalica", lambda: self.run_game(lambda: launch_main_game(self)), 3, 3),
+            ("Dice", lambda: self.run_game(lambda: launch_kocke_game(self)), 4, 1),
+            ("Sorting", lambda: self.run_game(lambda: launch_sort_game(self)), 4, 2),
+            ("Connect", lambda: self.run_game(lambda: launch_position_game(self)), 4, 3),
+            ("Snakes and Ladders", lambda: self.run_game(lambda: launch_snake_game(self)), 4, 0)
+
         ]
 
         # Create game buttons and store references.
@@ -309,7 +309,7 @@ class MainGameLauncher(tk.Tk):
             self.game_buttons.append(btn)
         about_btn = TransparentButton(
             self,
-            text="О кефалици",
+            text="About Kefalica",
             command=lambda: launch_about(self),
             font=BTN_FONT,
             width=BTN_WIDTH_PX,
@@ -323,7 +323,7 @@ class MainGameLauncher(tk.Tk):
         # --- Exit Button (remains enabled) ---
         exit_btn = TransparentButton(
             self,
-            text="Излаз",
+            text="Exit",
             command=self.exit_app,
             font=BTN_FONT,
             width=BTN_WIDTH_PX,


### PR DESCRIPTION
## Summary
- Localized main menu buttons and controls from Serbian to English.
- Converted Associations game messages and prompts into English.
- Translated sentence-building game interface and messages to English.
- Rewrote About dialog in English and replaced Close button text.

## Testing
- `python -m py_compile main.py gameAsocijacije.py gameRecenice.py about.py`


------
https://chatgpt.com/codex/tasks/task_e_6897ade32d948327aedeef6b1a9167c2